### PR TITLE
Fix: Resolve SignInButton warning and improve usage in AppBarSPA

### DIFF
--- a/src/shared/components/organisms/AppBar/AppBarSPA.tsx
+++ b/src/shared/components/organisms/AppBar/AppBarSPA.tsx
@@ -180,19 +180,25 @@ export const AppBarSPA: React.FC<AppBarSPAProps> = ({
             </SignedIn>
 
             <SignedOut>
-              <SignInButton mode="modal">
-                <IconButton>
-                  <Avatar
-                    sx={{
-                      width: 32,
-                      height: 32,
-                      bgcolor: '#2E3E50',
-                      fontSize: '0.9rem',
-                    }}
-                  >
-                    U
-                  </Avatar>
-                </IconButton>
+              {/* The SignInButton will pass its onClick to the child IconButton.
+                  Adding fallbackRedirectUrl for robustness.
+                  Wrapping with Tooltip for better UX.
+                  Using component="span" on IconButton as it can sometimes help with complex nesting. */}
+              <SignInButton mode="modal" fallbackRedirectUrl="/dashboard">
+                <Tooltip title="Iniciar Sesión">
+                  <IconButton component="span" aria-label="sign in button">
+                    <Avatar
+                      sx={{
+                        width: 32,
+                        height: 32,
+                        bgcolor: '#2E3E50',
+                        fontSize: '0.9rem',
+                      }}
+                    >
+                      U
+                    </Avatar>
+                  </IconButton>
+                </Tooltip>
               </SignInButton>
             </SignedOut>
           </Box>


### PR DESCRIPTION
Addresses a console warning related to SignInButton casing and recognition in the browser. The SignInButton usage within AppBarSPA has been updated to ensure proper rendering and event handling as per Clerk's documentation.

Changes include:
- Wrapping the custom sign-in icon (Avatar within IconButton) with a Tooltip.
- Adding `component="span"` to the IconButton to potentially improve nesting behavior with Material UI and Clerk components.
- Adding `fallbackRedirectUrl` to SignInButton for robustness.

This change is expected to resolve the warning and ensure the sign-in flow allows users to access the dashboard.